### PR TITLE
Fix Twist Behavior on Right Side

### DIFF
--- a/build/chain.py
+++ b/build/chain.py
@@ -261,7 +261,7 @@ class Chain:
             mc.setAttr(f"{decompose_matrix}.inputRotateOrder", 1) # Make sure the rotate order is set so that the Y is the twist axis
             twist_mult = mc.createNode("multiply", name=f"{joint}_MLT")
             mc.connectAttr(f"{decompose_matrix}.outputRotateY", f"{twist_mult}.input[0]")
-            mc.setAttr(f"{twist_mult}.input[1]", 0.5)
+            mc.setAttr(f"{twist_mult}.input[1]", 0.5 * mirror)
             mc.connectAttr(f"{twist_mult}.output", f"{mid_ctrl.ctrl_name}_SDK_GRP.rotateY")
 
             rSpline.matrix_spline_from_transforms(


### PR DESCRIPTION
Joints are pointed in a different direction on the right side due to joint mirroring, this fixes the twist behavior to account for that