### PR TITLE
More Robust Spine Tangent Length Calculation and Up Vector Axis for Matrix Spline

### DIFF
--- a/build/parts/hybrid_spine.py
+++ b/build/parts/hybrid_spine.py
@@ -275,8 +275,8 @@ class HybridSpine(rModule.RigModule):
 
     def output_rig(self):
         # Get spine length
-        start: om2.MPoint = om2.MPoint(mc.xform(self.guide_list[0], q=True, ws=True, t=True))
-        end: om2.MPoint = om2.MPoint(mc.xform(self.guide_list[2], q=True, ws=True, t=True))
+        start: om2.MPoint = om2.MPoint(mc.xform(self.base_guide, q=True, ws=True, t=True))
+        end: om2.MPoint = om2.MPoint(mc.xform(self.upper_chest_pivot_guide, q=True, ws=True, t=True))
         length: float = start.distanceTo(end)
 
         # Create the transforms to drive the actual spine curve/spline (two control points for each control, start mid and end)

--- a/build/parts/hybrid_spine.py
+++ b/build/parts/hybrid_spine.py
@@ -334,7 +334,7 @@ class HybridSpine(rModule.RigModule):
             stretch=False,
             parent=self.module_grp,
             primary_axis=(0, 1, 0),
-            secondary_axis=(0, 0, 1),
+            secondary_axis=(1, 0, 0),
             degree=3,
         )
 


### PR DESCRIPTION
Shouldn't change behavior much, may subtly change how the spine bends as the tangent length calculation is now based on the length between the base of the spine and the chest top pivot guide, rather than the (accidental) previous calculation which was from the base of the spine to the spine bend point (chest pivot guide.)

Secondary axis for the matrix spline has now been set to X, which is the axis of most rotation. This should be a little more robust. No compatibility problems, just more robust in certain edge cases.