### PR TITLE
Performance Fixes

### DIFF
--- a/build_scripts/Bobo_Build_Scripts.py
+++ b/build_scripts/Bobo_Build_Scripts.py
@@ -205,9 +205,10 @@ def make_sets():
         mc.group(part_list, name=f'{part}_vis_group')
         mc.connectAttr(f'Options_ctrl.{part}_Sculpt', f'{part}_vis_group.visibility', force=True)
 
-def skin_sculpt_jnts():
+def skin_sculpt_jnts() -> str | None:
     dir = f'{groups}/bobo/character/Rigs/Bobo/SkinFiles'
     rWeightNgIO.read_skin("Bobo_UBM", dir, 'Bobo_CurveNet')
+    return rUtil.get_last_deformer("Bobo_UBM")
 
 def build_basic_control(name='Main', shape='circle', size=5.0, color_rgb=(1, 1, 0), position=(0, 0, 0), rotation=(0, 0, 0)):
     """

--- a/build_scripts/SteveUtils/CurveNetAtHome.py
+++ b/build_scripts/SteveUtils/CurveNetAtHome.py
@@ -1,6 +1,8 @@
 import maya.cmds as mc
 import re
 
+from rjg.libs.util import create_deformer_bypass_nodes
+
 def uv_pin (
         object_to_pin: str, 
         surface: str, 
@@ -409,6 +411,7 @@ def create_curve_net_joints(GuidePrefix, SourceGeo):
         mc.rename(skin_cluster_name, new_name)
         print(f"Renamed existing skin cluster to {new_name}")
 
+
     if not mc.objExists('curve_net_null_joint'):
         NULL_Joint = mc.joint(name='curve_net_null_joint', p=(0, 0, 0))
         mc.setAttr(f"{NULL_Joint}.radius", 0.1)  # Set a small radius for visibility
@@ -431,7 +434,7 @@ def create_curve_net_joints(GuidePrefix, SourceGeo):
         dest_attr = f"curve_net_skin_cluster.bindPreMatrix[{i}]"
         mc.connectAttr(src_attr, dest_attr, force=True)
 
-
+    create_deformer_bypass_nodes(skin_cluster, name="curve_net")
 
 
     

--- a/build_scripts/build.py
+++ b/build_scripts/build.py
@@ -1,18 +1,21 @@
+import platform
+import sys
+from importlib import reload
+
 import maya.cmds as mc
 import maya.mel as mel
-import sys, platform
-from importlib import reload
 
 groups = 'G:' if platform.system() == 'Windows' else '/groups'
 mc.scriptEditorInfo(suppressWarnings=True,suppressInfo=True)
 
 import rjg.build.buildPart as rBuild
-import rjg.post.finalize as rFinal
 import rjg.build.prop as rProp
 import rjg.libs.file as rFile
 import rjg.libs.util as rUtil
 import rjg.post.dataIO.controls as rCtrlIO
+import rjg.post.finalize as rFinal
 import rjg.post.usd as rUSD
+
 reload(rUtil)
 reload(rProp)
 reload(rBuild)
@@ -21,8 +24,8 @@ reload(rFile)
 reload(rUSD)
 
 import pipe.m.space_switch as spsw
-
 from ngSkinTools2.api import plugin
+
 
 def ensure_ng_initialized():
     if not plugin.is_plugin_loaded():
@@ -36,10 +39,15 @@ def run(character, mp=None, gp=None, ep=None, cp=None, sp=None, pp=None, face=Tr
     import rjg.build_scripts
     reload(rjg.build_scripts)
     
+    import rjg.libs.util as rUtil
+    import rjg.post.dataIO.controls as rCtrlIO
     import rjg.post.dataIO.ng_weights as rWeightNgIO
     import rjg.post.dataIO.weights as rWeightIO
-    import rjg.post.dataIO.controls as rCtrlIO
-    import rjg.libs.util as rUtil
+    from rjg.build.parts.driverjoints import create_driver_joints
+    from rjg.build_scripts.Bobo_Build_Scripts import Clean_up_SculptJoints
+    from rjg.build_scripts.SteveUtils.CurveNetAtHome import create_curve_net_joints
+    from rjg.build_scripts.SteveUtils.importskins import import_weights
+    from rjg.build_scripts.UnrealCorrectives import BuildCorrectives, build_parents
     reload(rUtil)
     reload(rWeightNgIO)
     reload(rWeightIO)
@@ -315,8 +323,6 @@ def run(character, mp=None, gp=None, ep=None, cp=None, sp=None, pp=None, face=Tr
             )
 
         try:
-            sys.path.append(f'{groups}/bobo/pipeline/pipeline/software/maya/scripts/rjg/build/parts')
-            from driverjoints import create_driver_joints
             driver_controls = ['Major_Mouth_M_LowerLip_01_Mouth_CTRL', 'Major_Mouth_R_LowerLip_03_Mouth_CTRL', 'Major_Mouth_R_UpperLip_03_Mouth_CTRL', 'Major_Mouth_R_CornerLip_Mouth_CTRL', 'Major_Mouth_L_LowerLip_03_Mouth_CTRL', 'Major_Mouth_L_UpperLip_03_Mouth_CTRL', 'Major_Mouth_M_UpperLip_01_Mouth_CTRL', 'Major_Mouth_L_CornerLip_Mouth_CTRL', 'Eye_L_Upper_Major_L_CTRL', 'Eye_L_Lower_Major_L_CTRL', 'Eye_R_Lower_Major_R_CTRL', 'Eye_R_Upper_Major_R_CTRL', 'Brow_R_01_Major_R_CTRL', 'Brow_R_02_Major_R_CTRL', 'Brow_R_Inner_R_CTRL', 'Brow_R_Outer_R_CTRL', 'Brow_R_Master_R_CTRL', 'Brow_L_02_Major_L_CTRL', 'Brow_L_01_Major_L_CTRL', 'Brow_L_Inner_L_CTRL', 'Brow_L_Outer_L_CTRL', 'Brow_L_Master_L_CTRL', 'Jaw_M_root_M_CTRL']
             create_driver_joints(default_mult=10.0, ctrl_suffix="_CTRL", joint_suffix="_Driver", controls=driver_controls, parent='head')
         except:
@@ -884,10 +890,6 @@ def run(character, mp=None, gp=None, ep=None, cp=None, sp=None, pp=None, face=Tr
         import rjg.post.unrealJntRename as rUEJnt
         rUEJnt.unrealJntRename()
         # Build UE Correctives 
-        import sys
-        sys.path.append(f'{groups}/bobo/pipeline/pipeline/software/maya/scripts/rjg/build_scripts')
-        from UnrealCorrectives import BuildCorrectives
-        from UnrealCorrectives import build_parents 
         CorrGuides2 = ["upperarm_twistCor_01", "lowerarm_correctiveRoot", "upperarm_correctiveRoot", "thigh_correctiveRoot", "calf_correctiveRoot"]
         CorrParrent2 = ["upperarm_l", "lowerarm_l", "upperarm_l", "thigh_l", "calf_l"]
         build_parents(CorrGuides2, CorrParrent2)
@@ -955,8 +957,6 @@ def run(character, mp=None, gp=None, ep=None, cp=None, sp=None, pp=None, face=Tr
         for g in geo:
             sk = mc.skinCluster('root', g, tsb=False, skinMethod=1, n=f'clothingSkc{g}')[0]
             mc.copySkinWeights(ss='skinCluster11', ds=f'clothingSkc{g}', surfaceAssociation='closestPoint', noMirror=True, )
-        sys.path.append(f'{groups}/bobo/pipeline/pipeline/software/maya/scripts/rjg/build_scripts/SteveUtils')
-        from importskins import import_weights
         if character == 'Susaka':
             for g in ['Eye_L_Eye_L_Upper_curve_ribbon', 'Eye_R_Eye_R_Upper_curve_ribbon', 'Eye_L_Eye_L_Lower_curve_ribbon', 'Eye_R_Eye_R_Lower_curve_ribbon', 'Mouth_LowerLip_surf', 'Mouth_UpperLip_surf', 'Hood', 'Scarf', 'Collar', 'TempHair', 'RoboArm' ]:
                 import_weights(geo=g, path=f'{groups}/bobo/character/Rigs/{character}/SkinFiles')
@@ -966,8 +966,6 @@ def run(character, mp=None, gp=None, ep=None, cp=None, sp=None, pp=None, face=Tr
 
 
         try:
-            sys.path.append(f'{groups}/bobo/pipeline/pipeline/software/maya/scripts/rjg/build/parts')
-            from driverjoints import create_driver_joints
             driver_controls = ['Major_Mouth_M_LowerLip_01_Mouth_CTRL', 'Major_Mouth_R_LowerLip_03_Mouth_CTRL', 'Major_Mouth_R_UpperLip_03_Mouth_CTRL', 'Major_Mouth_R_CornerLip_Mouth_CTRL', 'Major_Mouth_L_LowerLip_03_Mouth_CTRL', 'Major_Mouth_L_UpperLip_03_Mouth_CTRL', 'Major_Mouth_M_UpperLip_01_Mouth_CTRL', 'Major_Mouth_L_CornerLip_Mouth_CTRL', 'Eye_L_Upper_Major_L_CTRL', 'Eye_L_Lower_Major_L_CTRL', 'Eye_R_Lower_Major_R_CTRL', 'Eye_R_Upper_Major_R_CTRL', 'Brow_R_01_Major_R_CTRL', 'Brow_R_02_Major_R_CTRL', 'Brow_R_Inner_R_CTRL', 'Brow_R_Outer_R_CTRL', 'Brow_R_Master_R_CTRL', 'Brow_L_02_Major_L_CTRL', 'Brow_L_01_Major_L_CTRL', 'Brow_L_Inner_L_CTRL', 'Brow_L_Outer_L_CTRL', 'Brow_L_Master_L_CTRL', 'Jaw_M_root_M_CTRL']
             create_driver_joints(default_mult=10.0, ctrl_suffix="_CTRL", joint_suffix="_Driver", controls=driver_controls, parent='head')
         except:
@@ -1007,8 +1005,8 @@ def run(character, mp=None, gp=None, ep=None, cp=None, sp=None, pp=None, face=Tr
 
     if character == 'Sharkguy':
         import sys
-        sys.path.append(f'{groups}/bobo/pipeline/pipeline/software/maya/scripts/rjg/build_scripts')
-        from Sharkguy_Build_Scripts import ribbons
+
+        from rjg.build_scipts.Sharkguy_Build_Scripts import ribbons
         ribbons()
         bindjoints = mc.select(mc.listRelatives("SKEL", ad=True, type="joint"))
         mc.select(f'{character}_UBM')
@@ -1024,8 +1022,6 @@ def run(character, mp=None, gp=None, ep=None, cp=None, sp=None, pp=None, face=Tr
             sk = mc.skinCluster('root_M_JNT', g, tsb=False, skinMethod=1, n=f'clothingSkc{g}')[0]
             mc.copySkinWeights(ss='skinCluster11', ds=f'clothingSkc{g}', surfaceAssociation='closestPoint', noMirror=True, )
         mc.delete("Extras_Guides")
-        sys.path.append(f'{groups}/bobo/pipeline/pipeline/software/maya/scripts/rjg/build_scripts/SteveUtils')
-        from importskins import import_weights
         for g in ['Eye_L_Eye_L_Upper_curve_ribbon', 'Eye_R_Eye_R_Upper_curve_ribbon', 'Eye_L_Eye_L_Lower_curve_ribbon', 'Eye_R_Eye_R_Lower_curve_ribbon', 'Mouth_LowerLip_surf', 'Mouth_UpperLip_surf', 'MouthGEO', 'RopesGEO', 'ShirtGEO', 'SwordGEO', 'PauldrenGEO', 'ChestGEO', 'RGautletGEO', 'BeltGEO', 'PantsGEO', 'LGautletGEO', 'OtherEyeBitGEO', 'EyesGEO']:
             import_weights(geo=g, path=f'{groups}/bobo/character/Rigs/{character}/SkinFiles')
         mc.parentConstraint('neck_02_FK_M_CTRL', 'Fin01_M_M_CTRL_CNST_GRP', mo=True)
@@ -1161,15 +1157,10 @@ def run(character, mp=None, gp=None, ep=None, cp=None, sp=None, pp=None, face=Tr
             mc.setAttr(f"{deformer2}.smoothingIterations", 2)
             mc.setAttr(f"{deformer2}.smoothingStep", .5)
             mc.deformerWeights("BoboDeltaMush.xml", im=True,  deformer=deformer2, path=f'{groups}/bobo/character/Rigs/Bobo/SkinFiles/')
-            sys.path.append(f'{groups}/bobo/pipeline/pipeline/software/maya/scripts/rjg/build_scripts/SteveUtils')
             #Add Sculpt points
-            sys.path.append(f'{groups}/bobo/pipeline/pipeline/software/maya/scripts/rjg/build_scripts')
             if face:
-                from CurveNetAtHome import create_curve_net_joints
                 create_curve_net_joints('Body', 'Bobo_UBM') 
                 skin_clusters = "curve_net_skin_cluster"
-                sys.path.append(f'{groups}/bobo/pipeline/pipeline/software/maya/scripts/rjg/build_scripts')
-                from Bobo_Build_Scripts import Clean_up_SculptJoints
                 mc.deformerWeights("ProjectFace.xml", im=True,  deformer='main_blendshapes', path=f'{groups}/bobo/character/Rigs/Bobo/SkinFiles/')
     
                 Clean_up_SculptJoints()

--- a/build_scripts/build.py
+++ b/build_scripts/build.py
@@ -44,8 +44,8 @@ def run(character, mp=None, gp=None, ep=None, cp=None, sp=None, pp=None, face=Tr
     import rjg.post.dataIO.ng_weights as rWeightNgIO
     import rjg.post.dataIO.weights as rWeightIO
     from rjg.build.parts.driverjoints import create_driver_joints
-    from rjg.build_scripts.Bobo_Build_Scripts import Clean_up_SculptJoints
-    from rjg.build_scripts.SteveUtils.CurveNetAtHome import create_curve_net_joints
+    from rjg.build_scripts import Bobo_Build_Scripts
+    from rjg.build_scripts.SteveUtils import CurveNetAtHome
     from rjg.build_scripts.SteveUtils.importskins import import_weights
     from rjg.build_scripts.UnrealCorrectives import BuildCorrectives, build_parents
     reload(rUtil)
@@ -557,15 +557,13 @@ def run(character, mp=None, gp=None, ep=None, cp=None, sp=None, pp=None, face=Tr
         if not_previs:
            try: 
                 rc.bobo_extras(body_mesh, extras)
-                from Bobo_Build_Scripts import Clean_Fur
-                Clean_Fur()
+                Bobo_Build_Scripts.Clean_Fur()
            except Exception as e:
                 mc.warning(e)
         else:
            try:
                rc.bobo_misc_pvis(body_mesh, ['Tounge', 'BotTeeth', 'HandClaws', 'TopTeeth', 'FootClaws', 'LeftEye', 'LeftCornea', 'RightEye', 'RightCornea', 'LeftPupil', 'RightPupil', 'FloofGeo', 'eyecover', 'FloofRoot'])  #['Tounge', 'BotTeeth', 'HandClaws', 'TopTeeth', 'FootClaws', 'LeftEye', 'LeftCornea', 'RightEye', 'RightCornea',]
-               from Bobo_Build_Scripts import Clean_Fur
-               Clean_Fur()
+               Bobo_Build_Scripts.Clean_Fur()
            except Exception as e:
                 mc.warning(e)
             
@@ -1159,24 +1157,21 @@ def run(character, mp=None, gp=None, ep=None, cp=None, sp=None, pp=None, face=Tr
             mc.deformerWeights("BoboDeltaMush.xml", im=True,  deformer=deformer2, path=f'{groups}/bobo/character/Rigs/Bobo/SkinFiles/')
             #Add Sculpt points
             if face:
-                create_curve_net_joints('Body', 'Bobo_UBM') 
+                CurveNetAtHome.create_curve_net_joints('Body', 'Bobo_UBM') 
                 skin_clusters = "curve_net_skin_cluster"
                 mc.deformerWeights("ProjectFace.xml", im=True,  deformer='main_blendshapes', path=f'{groups}/bobo/character/Rigs/Bobo/SkinFiles/')
     
-                Clean_up_SculptJoints()
+                Bobo_Build_Scripts.Clean_up_SculptJoints()
             mc.delete('CurveNet_Guide_Group')
-            from Bobo_Build_Scripts import clean_claws
-            clean_claws()
-            from Bobo_Build_Scripts import Clean_Fur
-            Clean_Fur()
+            Bobo_Build_Scripts.clean_claws()
+            Bobo_Build_Scripts.Clean_Fur()
 
         except Exception as e:
             print(e)
         #Fix Cog Rotate Order for Bobo to xzy
         if character == 'Bobo':
             mc.setAttr('COG_M_CTRL.rotateOrder', 3)
-            from Bobo_Build_Scripts import fix_position
-            fix_position()
+            Bobo_Build_Scripts.fix_position()
 
         '''from importskins import import_weights
         for g in ['HeadFur', 'BellyFur', 'ArmsFur']:

--- a/build_scripts/build.py
+++ b/build_scripts/build.py
@@ -1145,7 +1145,7 @@ def run(character, mp=None, gp=None, ep=None, cp=None, sp=None, pp=None, face=Tr
 
     if character == 'Bobo' and not_previs:
         try:
-            import sys
+            last_deformer = rUtil.get_last_deformer('Bobo_UBM')
             #Add Delta Mush
             deformer = mc.deltaMush('Bobo_UBM')[0]
             mc.setAttr(f"{deformer}.smoothingIterations", 20)
@@ -1165,6 +1165,11 @@ def run(character, mp=None, gp=None, ep=None, cp=None, sp=None, pp=None, face=Tr
             mc.delete('CurveNet_Guide_Group')
             Bobo_Build_Scripts.clean_claws()
             Bobo_Build_Scripts.Clean_Fur()
+
+            deformer_output_attr: str = f"{last_deformer}.outputGeometry[0]"
+            destination_mesh_attr: str = mc.listConnections(deformer_output_attr, source=False, destination=True, plugs=True)[0]
+            uv_pin_bypass: rUtil.BypassNodes = rUtil.create_mesh_connection_bypass(deformer_output_attr, destination_mesh_attr, name="curve_net_pin")
+            
 
         except Exception as e:
             print(e)

--- a/libs/util.py
+++ b/libs/util.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import maya.cmds as mc
 import maya.mel as mel
 import rjg.libs.control.ctrl as rCtrl
@@ -110,3 +111,82 @@ def import_poseInterpolator(path):
 def inplace_symlink(path):
     temp = f"{path}\\tmp"
     os.symlink(path, temp)
+
+def get_last_deformer(shape: str) -> str | None:
+    """Return the last deformer in the geometry’s deformation chain."""
+    deformers = mc.deformableShape(shape, chain=True) or []
+    if deformers:
+        return deformers[-1]
+    return None
+
+
+@dataclass
+class BypassNodes():
+    pre_node: str
+    def_node: str | None
+    post_node: str
+
+def create_mesh_connection_bypass(source: str, destination: str, name: str) -> BypassNodes:
+    # Disconnect
+    mc.disconnectAttr(source, destination)
+
+    # Create bypass nodes
+    pre_node: str = mc.createNode("groupParts", name=f"{name}_PRE")
+    post_node: str = mc.createNode("groupParts", name=f"{name}_POST")
+
+    # Rebuild connections
+    mc.connectAttr(source, f"{pre_node}.inputGeometry")
+    mc.connectAttr(f"{pre_node}.outputGeometry", f"{post_node}.inputGeometry")
+    mc.connectAttr(f"{post_node}.outputGeometry", destination)
+
+    # Add toggle attribute
+    mc.addAttr(pre_node, longName="bypassed", attributeType="bool")
+
+    return BypassNodes(pre_node=pre_node, def_node=None, post_node=post_node)
+
+
+
+def create_deformer_bypass_nodes(deformer: str, name: str) -> BypassNodes:
+    """
+    Wraps a deformer with groupPart nodes to make it easy to bypass it at any time 
+    by connecting the PRE outputGeometry to the POST inputGeometry.
+    Re-enabling is done by connecting the DEF outputGeometry to the POST inputGeometry.
+
+    Args:
+        deformer (str): Name of the deformer node to wrap with bypass nodes.
+        name (str): Base name used when naming the created groupParts nodes.
+
+    Returns:
+        BypassNodes: An object containing the names of the created bypass nodes.
+
+    Visualization:    
+    ┌───────┐   ┌────────────┐  ┌────────┐
+    │  PRE  ┼──►│  Deformer  ┼──►  POST  │
+    └───────┘   └─────┬──────┘  └────────┘
+                  ┌───▼───┐               
+                  │  DEF  │               
+                  └───────┘               
+    """
+    deformer_input_attr: str = f"{deformer}.input[0].inputGeometry"
+    deformer_output_attr: str = f"{deformer}.outputGeometry[0]"
+
+    # Get existing connections
+    source_mesh_attr: str = mc.listConnections(deformer_input_attr, source=True, destination=False, plugs=True)[0]
+    destination_mesh_attr: str = mc.listConnections(deformer_output_attr, source=False, destination=True, plugs=True)[0]
+    
+    # Create bypass nodes
+    pre_node: str = mc.createNode("groupParts", name=f"{name}_PRE")
+    def_node: str = mc.createNode("groupParts", name=f"{name}_DEF")
+    post_node: str = mc.createNode("groupParts", name=f"{name}_POST")
+    
+    # Rebuild connections
+    mc.connectAttr(source_mesh_attr, f"{pre_node}.inputGeometry")
+    mc.connectAttr(f"{pre_node}.outputGeometry", deformer_input_attr, force=True)
+    mc.connectAttr(deformer_output_attr, f"{post_node}.inputGeometry")
+    mc.connectAttr(f"{post_node}.outputGeometry", destination_mesh_attr, force=True)
+    mc.connectAttr(deformer_output_attr, f"{def_node}.inputGeometry")
+
+    # Add toggle attribute
+    mc.addAttr(def_node, longName="bypassed", attributeType="bool")
+
+    return BypassNodes(pre_node=pre_node, def_node=def_node, post_node=post_node)

--- a/post/BobofaceProject.py
+++ b/post/BobofaceProject.py
@@ -79,8 +79,18 @@ def project(body=None, char=None, f_model=None, f_rig=None, f_skel=None, extras=
 
     # project the face rig as an always-on blendShape
     #mc.xform(f_skel, t=[0, tY, 0])
+    f_shape: str = mc.listRelatives(f_model, shapes=True, noIntermediate=True, children=True)[0]
+    shape_input_attr: str = f"{f_shape}.inMesh"
+    shape_connection_attr: str = mc.listConnections(shape_input_attr, source=True, destination=False, plugs=True)[0]
     mc.blendShape(f_model, body, name='main_blendshapes', w=[(0, 1.0)], foc=True)
-
+    # Bypass shape node for face mesh
+    mc.connectAttr(shape_connection_attr, shape_input_attr, force=True)
+    # Bypass shape node for extras
+    shape_output_attr = f"{f_shape}.worldMesh[0]"
+    outbound_connections = mc.listConnections(shape_output_attr, source=False, destination=True, plugs=True)
+    if outbound_connections is not None:
+        for connection in outbound_connections:
+            mc.connectAttr(shape_connection_attr, connection, force=True)
     try:
         mc.select(f_extras, hi=True)
         f_ex_list = mc.ls(selection=True, type='transform')


### PR DESCRIPTION
Add ability to bypass sculpt joints for full GPU override (60+ FPS)
```
def toggle_sculpt_joints(namespace: str | None = None):
    if namespace is not None:
        bypass_prefix = f"{namespace}:curve_net"
    else:
        bypass_prefix = f"curve_net"
 
    bypassed = cmds.getAttr(f"{bypass_prefix}_DEF.bypassed")
    if bypassed:
        cmds.connectAttr(f"{bypass_prefix}_DEF.outputGeometry", f"{bypass_prefix}_POST.inputGeometry", force=True)
        cmds.connectAttr(f"{bypass_prefix}_pin_PRE.outputGeometry", f"{bypass_prefix}_pin_POST.inputGeometry", force=True)
        cmds.setAttr(f"{bypass_prefix}_DEF.bypassed", 0)
    else:
        cmds.connectAttr(f"{bypass_prefix}_PRE.outputGeometry", f"{bypass_prefix}_POST.inputGeometry", force=True)
        cmds.disconnectAttr(f"{bypass_prefix}_pin_PRE.outputGeometry", f"{bypass_prefix}_pin_POST.inputGeometry")
        cmds.setAttr(f"{bypass_prefix}_DEF.bypassed", 1)
```