### PR TITLE
Add Basic Rig Versioning Capability

### DIFF
--- a/build_scripts/build.py
+++ b/build_scripts/build.py
@@ -5,6 +5,8 @@ from importlib import reload
 import maya.cmds as mc
 import maya.mel as mel
 
+
+
 groups = 'G:' if platform.system() == 'Windows' else '/groups'
 mc.scriptEditorInfo(suppressWarnings=True,suppressInfo=True)
 
@@ -49,6 +51,7 @@ def run(character, mp=None, gp=None, ep=None, cp=None, sp=None, pp=None, face=Tr
     from rjg.build_scripts.SteveUtils import CurveNetAtHome
     from rjg.build_scripts.SteveUtils.importskins import import_weights
     from rjg.build_scripts.UnrealCorrectives import BuildCorrectives, build_parents
+    from rjg.libs.metadata import create_versioning_script
     reload(rUtil)
     reload(rWeightNgIO)
     reload(rWeightIO)
@@ -69,6 +72,9 @@ def run(character, mp=None, gp=None, ep=None, cp=None, sp=None, pp=None, face=Tr
         extras = rFile.import_hierarchy(ep, parent='MODEL')[0]
     #Fun Camera Thing
     mc.viewFit('perspShape', fitFactor=1, all=True, animate=True)
+
+    # Versioning
+    create_versioning_script(rig_name=character, rig_version=2)
     
     #Fixing Names
     if character == 'Skeleton':

--- a/libs/metadata.py
+++ b/libs/metadata.py
@@ -1,0 +1,22 @@
+import importlib.util
+import maya.cmds as mc
+
+spec = importlib.util.find_spec("rjg.libs.versioning_script")
+script_string = ""
+if spec and spec.origin:
+    with open(file=spec.origin, mode="r") as script_file:
+        script_string = script_file.read()
+
+
+def create_versioning_script(rig_name: str, rig_version: float) -> str:
+    script_node: str = mc.createNode("script", name=f"{rig_name}_VERSIONING")
+    mc.setAttr(f"{script_node}.scriptType", 1)
+    mc.setAttr(f"{script_node}.sourceType", 1)
+
+    script = (
+        script_string.replace("{{RIG_NAME}}", rig_name)
+        .replace("{{RIG_VERSION}}", str(rig_version))
+        .replace("{{SCRIPT_NODE}}", script_node)
+    )
+
+    mc.setAttr(f"{script_node}.before", script, type="string")

--- a/libs/versioning_script.py
+++ b/libs/versioning_script.py
@@ -1,0 +1,26 @@
+import maya.cmds as mc
+
+rig_name = "{{RIG_NAME}}"
+rig_version = "{{RIG_VERSION}}"
+script_node_name = "{{SCRIPT_NODE}}"
+metadata_node_name = f"{rig_name}_RIG_METADATA"
+def get_namespace() -> str:
+    script_nodes = mc.ls(type="script", recursive=True)
+    for script_node in script_nodes:
+        if script_node_name in script_node:
+            return script_node.rsplit(":", 1)[0]
+
+if not mc.objExists(metadata_node_name):
+    metadata_node = mc.createNode("network", name=metadata_node_name)
+    mc.addAttr(metadata_node, longName="RIG_NAME", dataType="string")
+    mc.setAttr(f"{metadata_node}.RIG_NAME", rig_name, type="string")
+    mc.addAttr(metadata_node, longName="ORIGINAL_RIG_VERSION", attributeType="double")
+    mc.setAttr(f"{metadata_node}.ORIGINAL_RIG_VERSION", float(rig_version))
+    mc.addAttr(metadata_node, longName="RIG_VERSION", attributeType="double")
+    mc.setAttr(f"{metadata_node}.RIG_VERSION", float(rig_version))
+else:
+    rig_version= float(rig_version)
+    scene_rig_version = mc.getAttr(f"{metadata_node_name}.RIG_VERSION")
+    if rig_version > scene_rig_version:
+        rig_namespace: str = get_namespace()
+        print(f"{rig_name} is now newer than the version first referenced into this file.")


### PR DESCRIPTION
This works by dynamically generating a script node on rig build that runs on file open in anim shots. On first open it creates a metadata network node and stores the rig version. In future opens if that node exists it compares the reference file version and if it is newer can execute version update code.