### PR TITLE
Limb Stretch Fix

### DIFF
--- a/build/chain.py
+++ b/build/chain.py
@@ -2,7 +2,6 @@ import ast
 from importlib import reload
 from typing import Any
 
-from maya.api.OpenMaya import MVector
 import maya.cmds as mc
 import rjg.libs.attribute as rAttr
 import rjg.libs.common as rCommon
@@ -10,6 +9,7 @@ import rjg.libs.control.ctrl as rCtrl
 import rjg.libs.math as rMath
 import rjg.libs.spline as spline
 import rjg.libs.transform as rXform
+from maya.api.OpenMaya import MVector
 from rjg.libs.maya_api import node
 
 reload(rCtrl)
@@ -42,6 +42,7 @@ class Chain:
         point_constraint=False,
         scale_constraint=True,
         matrix_constraint=False,
+        keep_joint_orient: bool = False,
         connect_scale=False,
         parent=False,
         static=False,
@@ -154,7 +155,7 @@ class Chain:
             self.constraints = []
             for src, jnt in zip(pose_dict, self.joints):
                 if matrix_constraint:
-                    rXform.matrix_constraint(src, jnt, keep_offset=False)
+                    rXform.matrix_constraint(src, jnt, use_joint_orient=keep_joint_orient)
                 elif parent_constraint:
                     pac = mc.parentConstraint(src, jnt, mo=True)[0]
                     self.constraints.append(pac)
@@ -313,8 +314,20 @@ class Chain:
             source_transform = joint
             if first_joint_space is not None and index == 0:
                 source_transform = first_joint_space
-            rXform.matrix_constraint(source_transform=source_transform, constrain_transform=segment_grp, keep_offset=False)
-            rXform.matrix_constraint(source_transform=source_transform, constrain_transform=segment_ctl, keep_offset=False)
+            rXform.matrix_constraint(
+                source_transform=source_transform,
+                constrain_transform=segment_grp,
+                keep_offset=False,
+                scale=False,
+                shear=False,
+            )
+            rXform.matrix_constraint(
+                source_transform=source_transform,
+                constrain_transform=segment_ctl,
+                keep_offset=False,
+                scale=False,
+                shear=False,
+            )
 
                 
             start_jnt = joint
@@ -377,20 +390,35 @@ class Chain:
 
             spline.matrix_spline_from_transforms(
                 transforms=[start_ctrl.ctrl_name, end_ctrl.ctrl_name],
-                transforms_to_pin=[f"{mid_ctrl.ctrl_name}_CNST_GRP"],
+                transforms_to_pin=[mid_ctrl.top],
                 degree=1,
                 primary_axis=(0, 1 * mirror, 0),
                 secondary_axis=sec_axis,
                 twist=False,
                 name=f"{joint}_Mid",
+                stretch=False,
             )
 
             # Handle End Control (follow the next segment, or if this is the last segment then only use the twist)
             if index == len(segments) - 1:
                 # Twist for end joint
-                mc.connectAttr(f"{quat_to_euler}.outputRotateY", f"{end_ctrl.ctrl_name}_CNST_GRP.rotateY")
+                mc.connectAttr(f"{quat_to_euler}.outputRotateY", f"{end_ctrl.top}.rotateY")
+                rXform.matrix_constraint(
+                    source_transform=end_jnt,
+                    constrain_transform=end_ctrl.top,
+                    keep_offset=False,
+                    rotate=False,
+                    scale=False,
+                    shear=False,
+                )
             else:
-                rXform.matrix_constraint(source_transform=end_jnt, constrain_transform=f"{end_ctrl.ctrl_name}_CNST_GRP", keep_offset=False)
+                rXform.matrix_constraint(
+                    source_transform=end_jnt,
+                    constrain_transform=end_ctrl.top,
+                    keep_offset=False,
+                    scale=False,
+                    shear=False,
+                )
 
             spline.matrix_spline_from_transforms(
                 transforms=[start_ctrl.ctrl_name, mid_ctrl.ctrl_name, end_ctrl.ctrl_name],

--- a/build/parts/bipedLimb.py
+++ b/build/parts/bipedLimb.py
@@ -427,8 +427,7 @@ class BipedLimb(rModule.RigModule, rIk.Ik, rFk.Fk):
             poc = True
         else:
             poc = False
-        limb_chain.create_from_transforms(orient_constraint=True,
-                                          point_constraint=poc,
+        limb_chain.create_from_transforms(matrix_constraint=True, keep_joint_orient=True,
                                           parent=self.skel)
         self.bind_joints = limb_chain.joints
         self.tag_bind_joints(self.bind_joints[:-1])

--- a/libs/transform.py
+++ b/libs/transform.py
@@ -236,6 +236,7 @@ def matrix_constraint(
     rotate: bool = True,
     scale: bool = True,
     shear: bool = True,
+    use_joint_orient: bool = False,
     lock_joint_orient: bool = True,
 ) -> None:
     """
@@ -301,18 +302,117 @@ def matrix_constraint(
     )
     mc.connectAttr(f"{mult_matrix}.matrixSum", f"{decompose_matrix}.inputMatrix")
     mc.connectAttr(f"{constrain_transform}.rotateOrder", f"{decompose_matrix}.inputRotateOrder")
-
+    
+    rotate_attr: str = f"{decompose_matrix}.outputRotate"
     # Drive transform with decomposed values
     # If it's a joint we have to do a whole bunch of other nonsense to account for joint orient
     if mc.nodeType(constrain_transform) == "joint":
         if scale:
             mc.setAttr(f"{constrain_transform}.segmentScaleCompensate", 0)
         if rotate:
-            mc.setAttr(f"{constrain_transform}.jointOrient", 0, 0, 0, type="float3")
-            if lock_joint_orient:
-                mc.setAttr(f"{constrain_transform}.jointOrient", lock=True)
+            if use_joint_orient:
+                # Check if the joint orient isn't about 0
+                joint_orient: tuple[float, float, float] = mc.getAttr(
+                    f"{constrain_transform}.jointOrient"
+                )[0]
+                if any(abs(i) > 0.01 for i in joint_orient):
+                    # Get our joint orient and turn it into a matrix
+                    orient_node: str = mc.createNode(
+                        "composeMatrix", name=f"{constraint_name}_OrientMatrix"
+                    )
+                    mc.connectAttr(
+                        f"{constrain_transform}.jointOrient", f"{orient_node}.inputRotate"
+                    )
+                    orient_matrix_attr = f"{orient_node}.outputMatrix"
+
+                    # We need to compose a different matrix to drive just the rotation due to the joint orient
+                    orient_offset_node: str = mc.createNode(
+                        "inverseMatrix", name=f"{constraint_name}_OrientOffsetMatrix"
+                    )
+                    orient_mult_matrix: str = mc.createNode(
+                        "multMatrix", name=f"{constraint_name}_ConstraintOrientMatrix"
+                    )
+                    orient_mult_index: int = 0
+
+                    # If we have an offset it'll be our first matrix in the multiplier (same as above)
+                    if keep_offset:
+                        mc.setAttr(
+                            f"{orient_mult_matrix}.matrixIn[{orient_mult_index}]",
+                            offset_matrix,
+                            type="matrix",
+                        )
+                        orient_mult_index += 1
+
+                    # Next we multiply by the world matrix of the source transform
+                    mc.connectAttr(
+                        f"{source_transform}.worldMatrix[0]",
+                        f"{orient_mult_matrix}.matrixIn[{orient_mult_index}]",
+                    )
+                    orient_mult_index += 1
+
+                    # Depending on if we need to take a parent into account we'll need a few extra nodes
+                    # (otherwise just pre-calculate a matrix and plop it in)
+                    # Bless Jared Love for figuring this out https://www.youtube.com/watch?v=_LNhZB8jQyo
+                    # Essentially we need to take the inverse of the orient * the world matrix of the parent and multiply by that
+                    if local_space:
+                        # Create a node to multiply the joint orient by the world matrix of the parent
+                        orient_parent_mult_matrix: str = mc.createNode(
+                            "multMatrix", name=f"{constraint_name}_ConstraintOrientMultMatrix"
+                        )
+                        mc.connectAttr(orient_matrix_attr, f"{orient_parent_mult_matrix}.matrixIn[0]")
+                        mc.connectAttr(
+                            f"{constrain_transform}.parentMatrix[0]",
+                            f"{orient_parent_mult_matrix}.matrixIn[1]",
+                        )
+
+                        # Create an inverse node and connect it to the result of the last step
+                        mc.connectAttr(
+                            f"{orient_parent_mult_matrix}.matrixSum",
+                            f"{orient_offset_node}.inputMatrix",
+                        )
+
+                        # Finally add this to a slot on the matrix multiplier node
+                        mc.connectAttr(
+                            f"{orient_offset_node}.outputMatrix",
+                            f"{orient_mult_matrix}.matrixIn[{orient_mult_index}]",
+                        )
+                        orient_mult_index += 1
+                    else:
+                        # If we don't care about a parent, just make a temp inverse node and store the inverse of the joint orient
+                        mc.connectAttr(
+                            f"{orient_node}.outputMatrix", f"{orient_offset_node}.inputMatrix"
+                        )
+                        inverse_orient_matrix = mc.getAttr(f"{orient_offset_node}.outputMatrix")
+
+                        # And then set it in a slot on the matrix multiplier
+                        mc.setAttr(
+                            f"{orient_mult_matrix}.matrixIn[{orient_mult_index}]",
+                            inverse_orient_matrix,
+                            type="matrix",
+                        )
+                        orient_mult_index += 1
+                        # Cleanup temp node
+                        mc.delete(orient_offset_node)
+
+                    #  Hook up the matrix multiplier to our decomposeMatrix and feed it into the rotate attribute of the joint
+                    orient_decompose_matrix: str = mc.createNode(
+                        "decomposeMatrix", name=f"{constraint_name}_ConstrainOrientDecompose"
+                    )
+                    mc.connectAttr(
+                        f"{orient_mult_matrix}.matrixSum", f"{orient_decompose_matrix}.inputMatrix"
+                    )
+                    mc.connectAttr(
+                        f"{constrain_transform}.rotateOrder",
+                        f"{orient_decompose_matrix}.inputRotateOrder",
+                    )
+                    rotate_attr = f"{orient_decompose_matrix}.outputRotate"
+            else:
+                mc.setAttr(f"{constrain_transform}.jointOrient", 0, 0, 0, type="float3")
+                if lock_joint_orient:
+                    mc.setAttr(f"{constrain_transform}.jointOrient", lock=True)
+        
     if rotate:
-        mc.connectAttr(f"{decompose_matrix}.outputRotate", f"{constrain_transform}.rotate")
+        mc.connectAttr(rotate_attr, f"{constrain_transform}.rotate")
         mc.setAttr(f"{constrain_transform}.rotateAxis", 0, 0, 0, type="float3")
     if translate:
         mc.connectAttr(f"{decompose_matrix}.outputTranslate", f"{constrain_transform}.translate")


### PR DESCRIPTION
Previously the bend-bows were scaled along with the underlying joints which gave some unwanted results. That combined with the poor connection from the driver joints to the actual deformation joints meant it exploded quite easily.

This changes that so that the bendbows follow the underlying joint without shear or scale.

The driving of the actual rig joints is now handled by a matrix_constraint that is joint orient aware.